### PR TITLE
Routr was outdated incremented to 0.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,15 +12,15 @@
   "dependencies": {
     "body-parser": "^1.6.4",
     "debug": "^2.0.0",
-    "dispatchr": "^0.2.1",
+    "dispatchr": "^0.2.x",
     "express": "^4.3.2",
     "express-state": "^1.2.0",
-    "fetchr": "^0.3.0",
-    "flux-router-component": "^0.2.0",
+    "fetchr": "^0.3.x",
+    "flux-router-component": "^0.2.x",
     "jade": "^1.3.1",
     "node-jsx": "^0.11.0",
     "react": "^0.11.1",
-    "routr": "^0.0.3"
+    "routr": "^0.0.x"
   },
   "devDependencies": {
     "jsx-loader": "^0.10.2",


### PR DESCRIPTION
Shouldnt all minor versions go through since there is no expected changes to be done on minors?
Thinking => "routr": "0.0.x"
