### PR TITLE
Upstate state on success

### DIFF
--- a/routing/stores/ApplicationStore.js
+++ b/routing/stores/ApplicationStore.js
@@ -25,7 +25,7 @@ function ApplicationStore(dispatcher) {
 
 ApplicationStore.storeName = 'ApplicationStore';
 ApplicationStore.handlers = {
-    'CHANGE_ROUTE_START': 'handleNavigate'
+    'CHANGE_ROUTE_SUCCESS': 'handleNavigate'
 };
 
 util.inherits(ApplicationStore, EventEmitter);


### PR DESCRIPTION
The ApplicationStore should not update the current page state until we successfully changed route.
