### PR TITLE
Use bundled webpack

### DIFF
--- a/chat/package.json
+++ b/chat/package.json
@@ -6,6 +6,6 @@
   "main": "server.js",
   "author": "Michael Ridgway <mridgway@yahoo-inc.com>",
   "scripts": {
-    "build": "webpack"
+    "build": "../node_modules/.bin/webpack"
   }
 }

--- a/routing/package.json
+++ b/routing/package.json
@@ -6,6 +6,6 @@
   "main": "server.js",
   "author": "Michael Ridgway <mridgway@yahoo-inc.com>",
   "scripts": {
-    "build": "webpack"
+    "build": "../node_modules/.bin/webpack"
   }
 }


### PR DESCRIPTION
`npm run build` fails if you do not have `webpack` installed globally. I changed the executable path to the bundled version to fix this.
