### PR TITLE
use propTypes to validate props

### DIFF
--- a/chat/components/ThreadListItem.jsx
+++ b/chat/components/ThreadListItem.jsx
@@ -22,7 +22,7 @@ var ReactPropTypes = React.PropTypes;
 
 var ThreadListItem = React.createClass({
 
-    props: {
+    propTypes: {
         thread: ReactPropTypes.object,
         currentThreadID: ReactPropTypes.string
     },


### PR DESCRIPTION
It should be `propTypes` instead of `props`

http://facebook.github.io/react/docs/component-specs.html#proptypes