### PR TITLE
Nav.jsx uses getDefaultProps instead of getInitialState

### DIFF
--- a/routing/components/Nav.jsx
+++ b/routing/components/Nav.jsx
@@ -7,15 +7,15 @@ var React = require('react');
 var NavLink = require('flux-router-component').NavLink;
 
 var Nav = React.createClass({
-    getInitialState: function () {
+    getDefaultProps: function () {
         return {
             selected: 'home',
             links: {}
         };
     },
     render: function() {
-        var selected = this.props.selected || this.state.selected,
-            links = this.props.links || this.state.links,
+        var selected = this.props.selected,
+            links = this.props.links,
             context = this.props.context,
             linkHTML = Object.keys(links).map(function (name) {
                 var className = '',


### PR DESCRIPTION
By using getDefaultProps we avoid having a component state that doesn't change over time:
http://facebook.github.io/react/docs/interactivity-and-dynamic-uis.html#what-should-go-in-state
And we also get easily the variables selected & links (by always getting them from the props).