### PR TITLE
Fix ApplicationStore routing to act on params changes in the same page

### DIFF
--- a/routing/stores/ApplicationStore.js
+++ b/routing/stores/ApplicationStore.js
@@ -20,12 +20,12 @@ var ApplicationStore = createStore({
         this.pageTitle = '';
     },
     handleNavigate: function (route) {
-        var pageName = route.config.page;
-        var page = this.pages[pageName];
-
-        if (pageName === this.getCurrentPageName()) {
+        if (this.currentRoute && (this.currentRoute.url === route.url)) {
             return;
         }
+
+        var pageName = route.config.page;
+        var page = this.pages[pageName];
 
         this.currentPageName = pageName;
         this.currentPage = page;


### PR DESCRIPTION
When triggering "navigate" programmatically, and only the parameters of
a route changes, then the store was not being updated.