### PR TITLE
Fixes for checksum failure in react-router example

### DIFF
--- a/react-router/client.js
+++ b/react-router/client.js
@@ -24,15 +24,28 @@ app.rehydrate(dehydratedState, function (err, context) {
     window.context = context;
     var mountNode = document.getElementById('app');
 
-    bootstrapDebug('React Rendering');
-
+    var firstRender = true;
     Router.run(app.getAppComponent(), HistoryLocation, function (Handler, state) {
-        context.executeAction(navigateAction, state, function () {
+        if (firstRender) {
+            // Don't call the action on the first render on top of the server rehydration
+            // Otherwise there is a race condition where the action gets executed before
+            // render has been called, which can cause the checksum to fail.
+            bootstrapDebug('React Rendering');
             React.withContext(context.getComponentContext(), function () {
                 React.render(React.createFactory(Handler)(), mountNode, function () {
                     bootstrapDebug('React Rendered');
                 });
             });
-        });
+            firstRender = false;
+        } else {
+            context.executeAction(navigateAction, state, function () {
+                bootstrapDebug('React Rendering');
+                React.withContext(context.getComponentContext(), function () {
+                    React.render(React.createFactory(Handler)(), mountNode, function () {
+                        bootstrapDebug('React Rendered');
+                    });
+                });
+            });
+        }
     });
 });

--- a/react-router/stores/ApplicationStore.js
+++ b/react-router/stores/ApplicationStore.js
@@ -8,33 +8,21 @@ var createStore = require('fluxible/utils/createStore');
 var ApplicationStore = createStore({
     storeName: 'ApplicationStore',
     handlers: {
-        'CHANGE_ROUTE_SUCCESS': 'handleNavigate'
+        'CHANGE_ROUTE': 'handleNavigate'
     },
     initialize: function (dispatcher) {
-        this.currentPage = null;
         this.currentRoute = null;
     },
     handleNavigate: function (route) {
-        if (pageName === this.getCurrentPageName()) {
+        if (this.currentRoute && route.path === this.currentRoute.path) {
             return;
         }
 
-        var pageName = route.config.page;
-        var page = this.pages[pageName];
-
-        this.currentPageName = pageName;
-        this.currentPage = page;
         this.currentRoute = route;
-        this.emit('change');
-    },
-    getCurrentPageName: function () {
-        return this.currentPageName;
+        this.emitChange();
     },
     getState: function () {
         return {
-            currentPageName: this.currentPageName,
-            currentPage: this.currentPage,
-            pages: this.pages,
             route: this.currentRoute
         };
     },
@@ -42,9 +30,6 @@ var ApplicationStore = createStore({
         return this.getState();
     },
     rehydrate: function (state) {
-        this.currentPageName = state.currentPageName;
-        this.currentPage = state.currentPage;
-        this.pages = state.pages;
         this.currentRoute = state.route;
     }
 });

--- a/react-router/stores/TimeStore.js
+++ b/react-router/stores/TimeStore.js
@@ -26,7 +26,7 @@ var TimeStore = createStore({
     },
     dehydrate: function () {
         return {
-            time: this.getState()
+            time: this.time.toString()
         };
     },
     rehydrate: function (state) {


### PR DESCRIPTION
Resolves https://github.com/yahoo/flux-examples/issues/101

The issue turns out to be a race condition on the client, where the executeAction call was called on the initial client rehydrate, which isn't what we want. So we have to make sure the action is not called on the initial client rehydrate.