### PR TITLE
Move from StateMixin to contextTypes

### DIFF
--- a/react-router/components/Nav.jsx
+++ b/react-router/components/Nav.jsx
@@ -5,15 +5,16 @@
 'use strict';
 var React = require('react');
 var Link = require('react-router').Link;
-var StateMixin = require('react-router').State;
 
 var Nav = React.createClass({
-    mixins: [StateMixin],
+    contextTypes: {
+        router: React.PropTypes.func.isRequired
+    },
     render: function() {
         return (
             <ul className="pure-menu pure-menu-open pure-menu-horizontal">
-                <li className={this.isActive('/') ? 'pure-menu-selected' : ''}><Link to='/'>Home</Link></li>
-                <li className={this.isActive('/about') ? 'pure-menu-selected' : ''}><Link to='/about'>About</Link></li>
+                <li className={this.context.router.isActive('/') ? 'pure-menu-selected' : ''}><Link to='/'>Home</Link></li>
+                <li className={this.context.router.isActive('/about') ? 'pure-menu-selected' : ''}><Link to='/about'>About</Link></li>
             </ul>
         );
     }


### PR DESCRIPTION
[context docs](https://github.com/rackt/react-router/blob/4ec1f289962217dbd84a8f60d306cfd4d45bf561/docs/api/RouterContext.md) as of this commit.

fixes deprecation warnings: ![screenshot 2015-03-24 02 20 59](https://cloud.githubusercontent.com/assets/551247/6798639/73ee7a12-d1cc-11e4-8587-8fbccea0ed13.png)