### PR TITLE
Fixes missing context in NavLink

### DIFF
--- a/fluxible-router/components/Nav.jsx
+++ b/fluxible-router/components/Nav.jsx
@@ -29,7 +29,7 @@ var Nav = React.createClass({
 
                     return (
                         <li className={className} key={link.path}>
-                            <NavLink routeName={link.page}>{link.label}</NavLink>
+                            <NavLink context={context} routeName={link.page}>{link.label}</NavLink>
                         </li>
                     );
                 }


### PR DESCRIPTION
Without this the example is broken