### PR TITLE
Support non-GET requests in Chat and Fluxible Router examples

### DIFF
--- a/chat/server.js
+++ b/chat/server.js
@@ -39,7 +39,11 @@ server.use(function (req, res, next) {
     });
 
     debug('Executing showChat action');
-    context.executeAction(navigateAction, { url: req.url, type: 'pageload' }, function (err) {
+    context.executeAction(navigateAction, {
+        url: req.url,
+        type: 'pageload',
+        method: req.method // Not needed but required to add any non-GET routes
+	}, function (err) {
 
         if (err) {
             if (err.status && err.status === 404) {

--- a/fluxible-router/server.js
+++ b/fluxible-router/server.js
@@ -22,7 +22,8 @@ server.use(function (req, res, next) {
 
     debug('Executing navigate action');
     context.executeAction(navigateAction, {
-        url: req.url
+        url: req.url,
+        method: req.method // Not needed but required to add any non-GET routes
     }, function (err) {
         if (err) {
             if (err.status && err.status === 404) {


### PR DESCRIPTION
I spent way too much time figuring out how to do this. I realize non-GET requests aren't necessary for these examples, but having code to indicate how to do this is immensely useful.