### PR TITLE
Update react-router example to fluxible 0.4.x

### DIFF
--- a/react-router/client.js
+++ b/react-router/client.js
@@ -12,6 +12,7 @@ var dehydratedState = window.App; // Sent from the server
 var Router = require('react-router');
 var HistoryLocation = Router.HistoryLocation;
 var navigateAction = require('./actions/navigate');
+var FluxibleComponent = require('fluxible/addons/FluxibleComponent');
 
 window.React = React; // For chrome dev tool support
 debug.enable('*');
@@ -22,9 +23,17 @@ function RenderApp(context, Handler){
     bootstrapDebug('React Rendering');
     var mountNode = document.getElementById('app');
     var Component = React.createFactory(Handler);
-    React.render(Component({context:context.getComponentContext()}), mountNode, function () {
-        bootstrapDebug('React Rendered');
-    });
+    React.render(
+        React.createElement(
+            FluxibleComponent,
+            { context: context.getComponentContext() },
+            Component()
+        ),
+        mountNode,
+        function () {
+            bootstrapDebug('React Rendered');
+        }
+    );
 }
 
 app.rehydrate(dehydratedState, function (err, context) {

--- a/react-router/components/Application.jsx
+++ b/react-router/components/Application.jsx
@@ -7,7 +7,7 @@ var React = require('react');
 var Nav = require('./Nav.jsx');
 var Timestamp = require('./Timestamp.jsx');
 var ApplicationStore = require('../stores/ApplicationStore');
-var FluxibleMixin = require('fluxible').FluxibleMixin;
+var FluxibleMixin = require('fluxible/addons/FluxibleMixin');
 var RouteHandler = require('react-router').RouteHandler;
 
 var Application = React.createClass({

--- a/react-router/components/Timestamp.jsx
+++ b/react-router/components/Timestamp.jsx
@@ -6,7 +6,7 @@
 var React = require('react');
 var updateTime = require('../actions/updateTime');
 var TimeStore = require('../stores/TimeStore');
-var FluxibleMixin = require('fluxible').FluxibleMixin;
+var FluxibleMixin = require('fluxible/addons/FluxibleMixin');
 
 var Timestamp = React.createClass({
     mixins: [FluxibleMixin],

--- a/react-router/server.js
+++ b/react-router/server.js
@@ -11,6 +11,7 @@ var debug = require('debug')('Example');
 var React = require('react');
 var app = require('./app');
 var HtmlComponent = React.createFactory(require('./components/Html.jsx'));
+var FluxibleComponent = require('fluxible/addons/FluxibleComponent');
 var Router = require('react-router');
 
 var server = express();
@@ -30,7 +31,13 @@ server.use(function (req, res, next) {
             var Component = React.createFactory(Handler);
             var html = React.renderToStaticMarkup(HtmlComponent({
                 state: exposed,
-                markup: React.renderToString(Component({context:context.getComponentContext()}))
+                markup: React.renderToString(
+                    React.createElement(
+                        FluxibleComponent,
+                        { context: context.getComponentContext() },
+                        Component()
+                    )
+                )
             }));
 
             debug('Sending markup');


### PR DESCRIPTION
Wraps the router's `Handler` component into a `FluxibleComponent` on both server and client to properly handle context methods. Fixes undefined `getState` method in `FluxibleMixin`.
Also fixes `FluxibleMixin` require, which is now `require('fluxible/addons/FluxibleMixin')`.