### PR TITLE
fix the issue with updating the title on the client side

### DIFF
--- a/fluxible-router/components/Application.js
+++ b/fluxible-router/components/Application.js
@@ -15,10 +15,10 @@ class Application extends React.Component {
     }
     componentDidUpdate(prevProps) {
         let newProps = this.props;
-        if (newProps.pageTitle === prevProps.pageTitle) {
+        if (newProps.ApplicationStore.pageTitle === prevProps.ApplicationStore.pageTitle) {
             return;
         }
-        document.title = newProps.pageTitle;
+        document.title = newProps.ApplicationStore.pageTitle;
     }
     render() {
         var Handler = this.props.currentRoute.get('handler');


### PR DESCRIPTION
In newProps  and prevProps we do not have direct access to `pageTitle`, thereby I had  to access it through `ApplicationStore`
I am not sure if it is the best way to do it!?