### PR TITLE
Add deferred loading and rendering query parameters to show off various usage

### DIFF
--- a/chat/README.md
+++ b/chat/README.md
@@ -15,3 +15,7 @@ $ npm run dev
 This will use `nodemon` and `webpack` to watch for changes and restart and rebuild as needed.
 
 Open http://localhost:3000
+
+This example also includes different patterns for render and loading data.
+ * You can add `?load=0` to defer loading data until the client. A delay of 1 second is added on the client in order to make this more apparent.
+ * You can add `?render=0` to defer rendering until the client.

--- a/chat/client.js
+++ b/chat/client.js
@@ -2,13 +2,15 @@
  * Copyright 2014, Yahoo! Inc.
  * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
-/*global App, document, window */
+/*global App, document, window, location */
 'use strict';
 var React = require('react');
 var debug = require('debug');
 var bootstrapDebug = debug('Example');
 var app = require('./app');
-var dehydratedState = window.App; // Sent from the server
+var dehydratedState = window.App || {}; // Sent from the server
+var RouteStore = require('./stores/RouteStore');
+var navigateAction = require('fluxible-router').navigateAction;
 
 window.React = React; // For chrome dev tool support
 debug.enable('*');
@@ -18,11 +20,28 @@ app.rehydrate(dehydratedState, function (err, context) {
     if (err) {
         throw err;
     }
-    window.context = context;
-    var mountNode = document.getElementById('app');
+
+    window.context = context; // For debugging
 
     bootstrapDebug('React Rendering');
+    var mountNode = document.getElementById('app');
     React.render(context.createElement(), mountNode, function () {
         bootstrapDebug('React Rendered');
     });
+
+    // If server did not load data, fire off the navigateAction
+    if (!context.getActionContext().getStore(RouteStore).getCurrentRoute()) {
+        setTimeout(function () {
+            context.executeAction(navigateAction, { url: window.location.pathname + window.location.search, type: 'pageload' }, function (err) {
+                if (err) {
+                    if (err.statusCode && err.statusCode === 404) {
+                        next();
+                    } else {
+                        next(err);
+                    }
+                    return;
+                }
+            });
+        }, 1000);
+    }
 });

--- a/chat/client.js
+++ b/chat/client.js
@@ -30,7 +30,7 @@ app.rehydrate(dehydratedState, function (err, context) {
     });
 
     // If server did not load data, fire off the navigateAction
-    if (!context.getActionContext().getStore(RouteStore).getCurrentRoute()) {
+    if (!context.getStore(RouteStore).getCurrentRoute()) {
         setTimeout(function () {
             context.executeAction(navigateAction, { url: window.location.pathname + window.location.search, type: 'pageload' }, function (err) {
                 if (err) {

--- a/chat/components/MessageSection.jsx
+++ b/chat/components/MessageSection.jsx
@@ -40,7 +40,7 @@ var MessageSection = React.createClass({
         var messageListItems = this.props.messages.map(getMessageListItem);
         return (
             <div className="message-section">
-                <h3 className="message-thread-heading">{this.props.thread.name}</h3>
+                <h3 className="message-thread-heading">{this.props.thread && this.props.thread.name}</h3>
                 <ul className="message-list" ref="messageList">
                     {messageListItems}
                 </ul>

--- a/chat/server.js
+++ b/chat/server.js
@@ -43,7 +43,7 @@ function renderPage(req, res, context) {
 
     debug('Rendering Application component into html');
     var html = React.renderToStaticMarkup(HtmlComponent({
-        //state: exposed,
+        state: exposed,
         markup: mainMarkup
     }));
 

--- a/chat/server.js
+++ b/chat/server.js
@@ -30,6 +30,27 @@ fetchrPlugin.registerService(require('./services/message'));
 // Set up the fetchr middleware
 server.use(fetchrPlugin.getXhrPath(), fetchrPlugin.getMiddleware());
 
+function renderPage(req, res, context) {
+    debug('Exposing context state');
+    var exposed = 'window.App=' + serialize(app.dehydrate(context)) + ';';
+
+    var mainMarkup;
+    if ('0' === req.query.render) {
+        mainMarkup = '';
+    } else {
+        mainMarkup = React.renderToString(context.createElement());
+    }
+
+    debug('Rendering Application component into html');
+    var html = React.renderToStaticMarkup(HtmlComponent({
+        //state: exposed,
+        markup: mainMarkup
+    }));
+
+    debug('Sending markup');
+    res.send(html);
+}
+
 server.use(function (req, res, next) {
     var context = app.createContext({
         req: req, // The fetchr plugin depends on this
@@ -39,29 +60,21 @@ server.use(function (req, res, next) {
     });
 
     debug('Executing showChat action');
-    context.executeAction(navigateAction, { url: req.url, type: 'pageload' }, function (err) {
-
-        if (err) {
-            if (err.statusCode && err.statusCode === 404) {
-                next();
-            } else {
-                next(err);
+    if ('0' === req.query.load) {
+        renderPage(req, res, context);
+    } else {
+        context.executeAction(navigateAction, { url: req.url, type: 'pageload' }, function (err) {
+            if (err) {
+                if (err.statusCode && err.statusCode === 404) {
+                    next();
+                } else {
+                    next(err);
+                }
+                return;
             }
-            return;
-        }
-
-        debug('Exposing context state');
-        var exposed = 'window.App=' + serialize(app.dehydrate(context)) + ';';
-
-        debug('Rendering Application component into html');
-        var html = React.renderToStaticMarkup(HtmlComponent({
-            state: exposed,
-            markup: React.renderToString(context.createElement())
-        }));
-
-        debug('Sending markup');
-        res.send(html);
-    });
+            renderPage(req, res, context);
+        });
+    }
 });
 
 var port = process.env.PORT || 3000;


### PR DESCRIPTION
Adds the following query params:

 * `?load=0` - defers navigateAction until client, renders shell on server
 * `?render=0` - executes actions on server and dehydrates data, but defers render to client side
 * `?load=0&render=0` - Sends an empty HTML shell and does everything on the client