### PR TITLE
Add webpack-dev-server with react-hot-loader for chat example

### DIFF
--- a/chat/package.json
+++ b/chat/package.json
@@ -6,6 +6,7 @@
   "main": "server.js",
   "author": "Michael Ridgway <mridgway@yahoo-inc.com>",
   "scripts": {
-    "dev": "grunt --gruntfile ../Gruntfile.js --taskName chat"
+    "dev": "node webpack-dev-server.js & PORT=3001 nodemon server.js -e js,jsx",
+    "start": "node server.js"
   }
 }

--- a/chat/webpack-dev-server.js
+++ b/chat/webpack-dev-server.js
@@ -1,0 +1,15 @@
+var webpack = require('webpack');
+var WebpackDevServer = require('webpack-dev-server');
+var config = require('./webpack.config');
+
+new WebpackDevServer(webpack(config), {
+    publicPath: config.output.publicPath,
+    hot: true,
+    historyApiFallback: true,
+    quiet: true,
+    proxy: {
+        '*': { target: 'http://localhost:3001' }
+    }
+}).listen(3000, function () {
+    console.log('Webpack Dev Server listening on port 3000');
+});

--- a/chat/webpack.config.js
+++ b/chat/webpack.config.js
@@ -1,0 +1,39 @@
+var path = require('path');
+var webpack = require('webpack');
+
+module.exports = {
+    resolve: {
+        extensions: ['', '.js', '.jsx']
+    },
+    entry: [
+        'webpack-dev-server/client?http://localhost:3000',
+        'webpack/hot/only-dev-server',
+        './client.js'
+    ],
+    output: {
+        path: path.resolve('./build/js'),
+        filename: 'client.js',
+        publicPath: '/public/js/'
+    },
+    module: {
+        loaders: [
+            { test: /\.css$/, loader: 'style!css' },
+            {
+                test: /\.(js|jsx)$/,
+                exclude: /node_modules/,
+                loaders: [
+                    require.resolve('react-hot-loader'),
+                    require.resolve('babel-loader')
+                ]
+            }
+        ]
+    },
+    plugins: [
+        new webpack.HotModuleReplacementPlugin(),
+        new webpack.NoErrorsPlugin(),
+        // Protects against multiple React installs when npm linking
+        new webpack.NormalModuleReplacementPlugin(/^react?$/, require.resolve('react')),
+        new webpack.NormalModuleReplacementPlugin(/^react(\/addons)?$/, require.resolve('react/addons'))
+    ],
+    devtool: 'eval'
+};

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "grunt-nodemon": "^0.4.0",
     "grunt-webpack": "^1.0.8",
     "nodemon": "^1.2.1",
+    "react-hot-loader": "^1.2.8",
     "webpack": "^1.4.12",
     "webpack-dev-server": "^1.6.5"
   }


### PR DESCRIPTION
This adds webpack-dev-server and hot reloading workflow to the chat example. If we like this I will go ahead and add it for the other examples and the generator.

In dev (`npm run dev`), the dev-server will run on port 3000 and proxy to the app running on port 3001 for paths that do not match webpack's. The client files will be hot reloaded and the app server will restart on changes to the filesystem, but it will not affect the client app running. To see the new server generated markup, simply refresh the page.