### PR TITLE
delete old change handler

### DIFF
--- a/chat/components/MessageSection.jsx
+++ b/chat/components/MessageSection.jsx
@@ -56,13 +56,6 @@ var MessageSection = React.createClass({
     _scrollToBottom: function() {
         var ul = this.refs.messageList.getDOMNode();
         ul.scrollTop = ul.scrollHeight;
-    },
-
-    /**
-     * Event handler for 'change' events coming from the MessageStore
-     */
-    _onChange: function() {
-        this.setState(this.getStateFromStores());
     }
 
 });


### PR DESCRIPTION
looks like this was missed in the migration to `connectToStores`