### PR TITLE
delete another old change handler

### DIFF
--- a/chat/components/ThreadSection.jsx
+++ b/chat/components/ThreadSection.jsx
@@ -49,13 +49,6 @@ var ThreadSection = React.createClass({
                 </ul>
             </div>
         );
-    },
-
-    /**
-     * Event handler for 'change' events coming from the stores
-     */
-    _onChange: function() {
-        this.setState(this.getStateFromStores());
     }
 
 });


### PR DESCRIPTION
looks like this was missed in the migration to `connectToStores`